### PR TITLE
[DMS-520] Support arm64 dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project includes a series of *gradle* tasks:
 
 ## Build container
 
-To build the container with a dev tag, simply run `docker build -t edfialliance/ed-fi-kafka-connect:dev .` from the `kafka` directory.
+To build the container with a dev tag, simply run `docker build -t edfialliance/ed-fi-kafka-connect:dev --build-context parentdir=../  .` from the `kafka` directory.
 
 ## Legal Information
 

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM gradle:8.2.1-jdk-focal@sha256:78b95c865c1bcb50ced01501e6a9c6c9bcc181be93c1ea723ff4b58b2f7e9a96 AS build
+FROM gradle:8.2.1-jdk-focal@sha256:89b352a0d0d40bb7294cbe5ffd4d9a8824cac6174f9ecc786c0d53ef4663863f AS build
 COPY --chown=gradle:gradle /ed-fi-kafka-connect-transforms /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle installDist --no-daemon

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -47,7 +47,11 @@ RUN tar -xvf ${opensearch} && \
 RUN tar -xvf ${elasticsearch} && \
     rm ${elasticsearch}
 
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
 COPY --from=parentdir LICENSE /kafka/connect/EDFI_LICENSE
+# Named context support https://github.com/hadolint/hadolint/issues/830
+# hadolint ignore=DL3022
 COPY --from=parentdir NOTICES.md /kafka/connect/EDFI_NOTICES.md
 
 COPY --from=build /home/gradle/src/build/libs /kafka/connect/ed-fi-kafka-connect-transforms


### PR DESCRIPTION
- Updated gradle base image to allow docker to pull the image based on the host architecture
- Updated readme to fix issue while building the image locally
- Fixed Hadolint DL3022 following https://github.com/hadolint/hadolint/issues/830